### PR TITLE
Update smoelenboek.css

### DIFF
--- a/css/smoelenboek.css
+++ b/css/smoelenboek.css
@@ -81,7 +81,6 @@ section.coverPage canvas {
 .naam { height: 24px; color: #4277c1; font-size: 12pt; font-weight: bold; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .telefoon { height: 17px; }
 .email { height: 36px; word-break: break-all; }
-.functie { word-break: break-all; }
 
 .photo { width: 100%; height: 206px; }
 .photo canvas { width: 100%; height: 100%; }


### PR DESCRIPTION
Remove `.functie { word-break: break-all; }`, as it makes no sense to break the words here for longer descriptions.